### PR TITLE
Fix packages sort

### DIFF
--- a/main.go
+++ b/main.go
@@ -271,17 +271,21 @@ func combineAPIPackages(pkgs []*types.Package) ([]*apiPackage, error) {
 	for _, v := range pkgMap {
 		out = append(out, v)
 	}
+	sortPackages(out)
 
-	sort.SliceStable(out, func(i, j int) bool {
-		a := out[i]
-		b := out[j]
-		if a.apiGroup < b.apiGroup {
-			return true
+	return out, nil
+}
+
+// sortPackages sorts the given packages in a consistent alphabetical order.
+func sortPackages(packages []*apiPackage) {
+	sort.SliceStable(packages, func(i, j int) bool {
+		a := packages[i]
+		b := packages[j]
+		if a.apiGroup != b.apiGroup {
+			return a.apiGroup < b.apiGroup
 		}
 		return a.apiVersion < b.apiVersion
 	})
-
-	return out, nil
 }
 
 // isVendorPackage determines if package is coming from vendor/ dir.

--- a/main.go
+++ b/main.go
@@ -75,7 +75,7 @@ type apiPackage struct {
 
 func (v *apiPackage) identifier() string { return fmt.Sprintf("%s/%s", v.apiGroup, v.apiVersion) }
 
-func init() {
+func initFlags() {
 	klog.InitFlags(nil)
 	flag.Set("alsologtostderr", "true") // for klog
 	flag.Parse()
@@ -113,6 +113,8 @@ func resolveTemplateDir(dir string) error {
 
 func main() {
 	defer klog.Flush()
+
+	initFlags()
 
 	f, err := os.Open(*flConfig)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_sortPackages(t *testing.T) {
+	tests := []struct {
+		name string
+		packages []*apiPackage
+		expected []*apiPackage
+	}{
+		{
+			name: "sort by group then version",
+			packages: []*apiPackage{
+				{
+					apiGroup:   "a",
+					apiVersion: "v1",
+				},
+				{
+					apiGroup:   "c",
+					apiVersion: "v1beta1",
+				},
+				{
+					apiGroup:   "b",
+					apiVersion: "v1beta1",
+				},
+				{
+					apiGroup:   "c",
+					apiVersion: "v1",
+				},
+				{
+					apiGroup:   "b",
+					apiVersion: "v1",
+				},
+				{
+					apiGroup:   "a",
+					apiVersion: "v1beta1",
+				},
+			},
+			expected: []*apiPackage{
+				{
+					apiGroup:   "a",
+					apiVersion: "v1",
+				},
+				{
+					apiGroup:   "a",
+					apiVersion: "v1beta1",
+				},
+				{
+					apiGroup:   "b",
+					apiVersion: "v1",
+				},
+				{
+					apiGroup:   "b",
+					apiVersion: "v1beta1",
+				},
+				{
+					apiGroup:   "c",
+					apiVersion: "v1",
+				},
+				{
+					apiGroup:   "c",
+					apiVersion: "v1beta1",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sortPackages(tt.packages)
+			if !reflect.DeepEqual(tt.expected, tt.packages) {
+				t.Error("Unexpected packages ordering")
+			}
+		})
+	}
+}


### PR DESCRIPTION
We want to compare resource group first, then fallback to resource
version if the group is the same. The previous version of the sort
algorithm did not work as expected in some situations, by comparing
resources version even though their group does not match.

Only the case where groupA < groupB was considered for group comparison,
leading to a version comparison if groupA > groupB.

This commit fixes it by making sure we evaluate version comparison only
if groups are the same.

It is verified by a unit test that does not pass with the previous
version of the sort algorithm.

To properly run a unit test in the same package as `main.go`, I
had to work around [this issue]{https://github.com/golang/go/issues/31859).